### PR TITLE
Enclose all response and error messages

### DIFF
--- a/src/main/java/park/commands/AddCommand.java
+++ b/src/main/java/park/commands/AddCommand.java
@@ -26,8 +26,7 @@ public class AddCommand extends Command {
     public void execute(TaskList tasks, Ui ui, Storage storage) throws ParkException {
         tasks.add(t);
         storage.append(t);
-        ui.setResponse("Got it. I've added this task:" + t + "\n");
-        ui.setResponse("Now you have " + tasks.size() + " tasks in the list.");
+        ui.setAddResponse(t.toString(), tasks.size());
     }
 
     @Override

--- a/src/main/java/park/commands/DeleteCommand.java
+++ b/src/main/java/park/commands/DeleteCommand.java
@@ -27,11 +27,10 @@ public class DeleteCommand extends Command {
         try {
             Task t = tasks.get(index);
             storage.delete(t);
-            ui.setResponse("Noted. I've removed this task:" + t + "\n");
             tasks.delete(index);
-            ui.setResponse("Now you have " + tasks.size() + " tasks in the list.");
+            ui.setDeleteResponse(t.toString(), tasks.size());
         } catch (IndexOutOfBoundsException e) {
-            throw new ParkException("invalid index");
+            throw ParkException.invalidIndexException();
         }
     }
 

--- a/src/main/java/park/commands/ExitCommand.java
+++ b/src/main/java/park/commands/ExitCommand.java
@@ -11,7 +11,7 @@ public class ExitCommand extends Command{
 
     @Override
     public void execute(TaskList tasks, Ui ui, Storage storage) {
-        ui.setResponse("Bye. Hope to see you again soon!");
+        ui.setExitResponse();
     }
 
     @Override

--- a/src/main/java/park/commands/FindCommand.java
+++ b/src/main/java/park/commands/FindCommand.java
@@ -22,20 +22,15 @@ public class FindCommand extends Command {
     @Override
     public void execute(TaskList tasks, Ui ui, Storage storage) {
         int counter = 1;
-        StringBuilder result = new StringBuilder();
+        StringBuilder matchingTasks = new StringBuilder();
         for (int i = 0; i < tasks.size(); i++) {
             String task = tasks.get(i).toString();
             if (task.contains(keyword)) {
-                result.append(counter).append(".").append(task).append("\n");
+                matchingTasks.append(counter).append(".").append(task).append("\n");
                 counter++;
             }
         }
-        if (result.isEmpty()) {
-            ui.setResponse("There are no matching tasks.");
-        } else {
-            ui.setResponse("Here are the matching tasks in your list:" + "\n");
-            ui.setResponse(result.toString());
-        }
+        ui.setFindResponse(matchingTasks);
     }
 
     @Override

--- a/src/main/java/park/commands/ListCommand.java
+++ b/src/main/java/park/commands/ListCommand.java
@@ -11,14 +11,11 @@ public class ListCommand extends Command {
 
     @Override
     public void execute(TaskList tasks, Ui ui, Storage storage) {
-        if (tasks.isEmpty()) {
-            ui.setResponse("There are no tasks in your list.");
-        } else {
-            ui.setResponse("Here are the tasks in your list:" + "\n");
-            for (int i = 0; i < tasks.size(); i++) {
-                ui.setResponse((i + 1) + "." + tasks.get(i) + "\n");
-            }
+        StringBuilder taskList = new StringBuilder();
+        for (int i = 0; i < tasks.size(); i++) {
+            taskList.append(i + 1).append(".").append(tasks.get(i)).append("\n");
         }
+        ui.setListResponse(taskList);
     }
 
     @Override

--- a/src/main/java/park/commands/MarkCommand.java
+++ b/src/main/java/park/commands/MarkCommand.java
@@ -30,9 +30,9 @@ public class MarkCommand extends Command {
             t.mark();
             String newLine = t.encode();
             storage.modify(oldLine, newLine);
-            ui.setResponse("OK, I've marked this task as done:" + t);
+            ui.setMarkResponse(t.toString());
         } catch (IndexOutOfBoundsException e) {
-            throw new ParkException("invalid index");
+            throw ParkException.invalidIndexException();
         }
     }
 

--- a/src/main/java/park/commands/UnmarkCommand.java
+++ b/src/main/java/park/commands/UnmarkCommand.java
@@ -30,9 +30,9 @@ public class UnmarkCommand extends Command {
             t.unmark();
             String newLine = t.encode();
             storage.modify(oldLine, newLine);
-            ui.setResponse("OK, I've marked this task as not done yet:" + t);
+            ui.setUnmarkResponse(t.toString());
         } catch (IndexOutOfBoundsException e) {
-            throw new ParkException("invalid index");
+            throw ParkException.invalidIndexException();
         }
     }
 

--- a/src/main/java/park/exceptions/ParkException.java
+++ b/src/main/java/park/exceptions/ParkException.java
@@ -5,9 +5,55 @@ package park.exceptions;
  */
 public class ParkException extends Exception {
 
-    public ParkException() {}
-
     public ParkException(String message) {
         super(message);
+    }
+
+    public static ParkException invalidIndexException() {
+        return new ParkException("invalid index");
+    }
+
+    public static ParkException missingIndexException() {
+        return new ParkException("missing index");
+    }
+
+    public static ParkException invalidInputException() {
+        return new ParkException("invalid input");
+    }
+
+    public static ParkException missingDescException() {
+        return new ParkException("please provide a description");
+    }
+
+    public static ParkException deadlineFormatException() {
+        return new ParkException("please use the format: desc /by deadline");
+    }
+
+    public static ParkException dateTimeFormatException() {
+        return new ParkException("please input DateTime in format: yyyy-MM-dd HHmm");
+    }
+
+    public static ParkException eventFormatException() {
+        return new ParkException("please use the format: desc /from start /to end");
+    }
+
+    public static ParkException missingKeywordException() {
+        return new ParkException("please provide a keyword");
+    }
+
+    public static ParkException createFileException() {
+        return new ParkException("error creating file");
+    }
+
+    public static ParkException loadFileException() {
+        return new ParkException("error loading file");
+    }
+
+    public static ParkException writeFileException() {
+        return new ParkException("error writing to file");
+    }
+
+    public static ParkException fileCorruptedException() {
+        return new ParkException("file corrupted, loading new empty task list");
     }
 }

--- a/src/main/java/park/parser/Parser.java
+++ b/src/main/java/park/parser/Parser.java
@@ -36,9 +36,9 @@ public class Parser {
                 int index = Integer.parseInt(strIndex) - 1;
                 return new MarkCommand(index);
             } catch (IndexOutOfBoundsException e) {
-                throw new ParkException("missing index");
+                throw ParkException.missingIndexException();
             } catch (NumberFormatException e) {
-                throw new ParkException("invalid index");
+                throw ParkException.invalidIndexException();
             }
         } else if (userInput.startsWith("unmark")) {
             try {
@@ -46,9 +46,9 @@ public class Parser {
                 int index = Integer.parseInt(strIndex) - 1;
                 return new UnmarkCommand(index);
             } catch (IndexOutOfBoundsException e) {
-                throw new ParkException("missing index");
+                throw ParkException.missingIndexException();
             } catch (NumberFormatException e) {
-                throw new ParkException("invalid index");
+                throw ParkException.invalidIndexException();
             }
         } else if (userInput.startsWith("delete")) {
             try {
@@ -56,80 +56,80 @@ public class Parser {
                 int index = Integer.parseInt(strIndex) - 1;
                 return new DeleteCommand(index);
             } catch (IndexOutOfBoundsException e) {
-                throw new ParkException("missing index");
+                throw ParkException.missingIndexException();
             } catch (NumberFormatException e) {
-                throw new ParkException("invalid index");
+                throw ParkException.invalidIndexException();
             }
         } else if (userInput.startsWith("todo")) {
             try {
                 String charAfterCommand = getChar(userInput, 4);
                 if (!charAfterCommand.equals(" ")) {
-                    throw new ParkException("invalid input");
+                    throw ParkException.invalidInputException();
                 }
                 String desc = userInput.substring(5);
                 if (desc.isEmpty()) {
-                    throw new ParkException("please provide a description");
+                    throw ParkException.missingDescException();
                 }
                 Task t = new ToDo(desc);
                 return new AddCommand(t);
             } catch (IndexOutOfBoundsException e) {
-                throw new ParkException("please provide a description");
+                throw ParkException.missingDescException();
             }
         } else if (userInput.startsWith("deadline")) {
             try {
                 String charAfterCommand = getChar(userInput, 8);
                 if (!charAfterCommand.equals(" ")) {
-                    throw new ParkException("invalid input");
+                    throw ParkException.invalidInputException();
                 }
                 String[] str = userInput.split(" /by ");
                 String desc = str[0].substring(9);
                 String by = str[1];
                 if (desc.isEmpty() || by.isEmpty()) {
-                    throw new ParkException("please provide a description and/or deadline");
+                    throw ParkException.deadlineFormatException();
                 }
                 Task t = new Deadline(desc, by);
                 return new AddCommand(t);
             } catch (IndexOutOfBoundsException e) {
-                throw new ParkException("please use the format: desc /by deadline");
+                throw ParkException.deadlineFormatException();
             } catch (DateTimeParseException e) {
-                throw new ParkException("please input DateTime in format: yyyy-MM-dd HHmm");
+                throw ParkException.dateTimeFormatException();
             }
         } else if (userInput.startsWith("event")) {
             try {
                 String charAfterCommand = getChar(userInput, 5);
                 if (!charAfterCommand.equals(" ")) {
-                    throw new ParkException("invalid input");
+                    throw ParkException.invalidInputException();
                 }
                 String[] str = userInput.split(" /");
                 String desc = str[0].substring(6);
                 String start = str[1].substring(5);
                 String end = str[2].substring(3);
                 if (desc.isEmpty() || start.isEmpty() || end.isEmpty()) {
-                    throw new ParkException("please provide desc, start, end");
+                    throw ParkException.eventFormatException();
                 }
                 Task t = new Event(desc, start, end);
                 return new AddCommand(t);
             } catch (IndexOutOfBoundsException e) {
-                throw new ParkException("please use the format: desc /from start /to end");
+                throw ParkException.eventFormatException();
             } catch (DateTimeParseException e) {
-                throw new ParkException("please input DateTime in format: yyyy-MM-dd HHmm");
+                throw ParkException.dateTimeFormatException();
             }
         } else if (userInput.startsWith("find")) {
             try {
                 String charAfterCommand = getChar(userInput, 4);
                 if (!charAfterCommand.equals(" ")) {
-                    throw new ParkException("invalid input");
+                    throw ParkException.invalidInputException();
                 }
                 String keyword = userInput.substring(5);
                 if (keyword.isEmpty()) {
-                    throw new ParkException("please provide a keyword");
+                    throw ParkException.missingKeywordException();
                 }
                 return new FindCommand(keyword);
             } catch (IndexOutOfBoundsException e) {
-                throw new ParkException("please provide a keyword");
+                throw ParkException.missingKeywordException();
             }
         } else {
-            throw new ParkException("invalid input");
+            throw ParkException.invalidInputException();
         }
     }
 

--- a/src/main/java/park/storage/Storage.java
+++ b/src/main/java/park/storage/Storage.java
@@ -44,7 +44,7 @@ public class Storage {
                 }
                 f.createNewFile();
             } catch (IOException e) {
-                throw new ParkException("Error creating file");
+                throw ParkException.createFileException();
             }
             return new TaskList();
         }
@@ -57,7 +57,7 @@ public class Storage {
             }
             return tasklist;
         } catch (IOException e) {
-            throw new ParkException("Error loading file");
+            throw ParkException.loadFileException();
         }
     }
 
@@ -73,7 +73,7 @@ public class Storage {
             fw.write(t.encode() + "\n");
             fw.close();
         } catch (IOException e) {
-            throw new ParkException("Error writing to file");
+            throw ParkException.writeFileException();
         }
     }
 
@@ -97,7 +97,7 @@ public class Storage {
             }
             Files.write(Path.of(filePath), modifiedLines);
         } catch (IOException e) {
-            throw new ParkException("Error writing to file");
+            throw ParkException.writeFileException();
         }
     }
 
@@ -118,7 +118,7 @@ public class Storage {
             }
             Files.write(Path.of(filePath), modifiedLines);
         } catch (IOException e) {
-            throw new ParkException("Error writing to file");
+            throw ParkException.writeFileException();
         }
     }
 
@@ -152,10 +152,10 @@ public class Storage {
                 }
                 return event;
             default:
-                throw new ParkException("file corrupted, loading new empty list");
+                throw ParkException.fileCorruptedException();
             }
         } catch (IndexOutOfBoundsException e) {
-            throw new ParkException("file corrupted, loading new empty list");
+            throw ParkException.fileCorruptedException();
         }
     }
 }

--- a/src/main/java/park/ui/Ui.java
+++ b/src/main/java/park/ui/Ui.java
@@ -4,6 +4,8 @@ import java.io.InputStream;
 import java.io.PrintStream;
 import java.util.Scanner;
 
+import park.task.Task;
+
 /**
  * Represents an object that deals with user inputs.
  */
@@ -58,7 +60,46 @@ public class Ui {
                 What can I do for you?""");;
     }
 
-    public void setResponse(String message) {
+    public void setMarkResponse(String task) {
+        setResponse("OK, I've marked this task as done:" + task);
+    }
+
+    public void setUnmarkResponse(String task) {
+        setResponse("OK, I've marked this task as not done yet:" + task);
+    }
+
+    public void setAddResponse(String task, int taskListSize) {
+        setResponse("Got it. I've added this task:" + task + "\n" + "Now you have " +
+                taskListSize + " tasks in the list.");
+    }
+
+    public void setDeleteResponse(String task, int taskListSize) {
+        setResponse("Noted. I've removed this task:" + task + "\n" + "Now you have " +
+                taskListSize + " tasks in the list.");
+    }
+
+    public void setExitResponse() {
+        setResponse("Bye. Hope to see you again soon!");
+    }
+
+    public void setFindResponse(StringBuilder matchingTasks) {
+        if (matchingTasks.isEmpty()) {
+            setResponse("There are no matching tasks.");
+        } else {
+            setResponse("Here are the matching tasks in your list:" + "\n" +
+                    matchingTasks);
+        }
+    }
+
+    public void setListResponse(StringBuilder taskList) {
+        if (taskList.isEmpty()) {
+            setResponse("There are no tasks in your list.");
+        } else {
+            setResponse("Here are the tasks in your list:" + "\n" + taskList);
+        }
+    }
+
+    private void setResponse(String message) {
         parkResponse.append(message);
     }
 


### PR DESCRIPTION
Response and error messages are manually entered each time they are invoked. This results in the same messages being entered multiple times.

Removing such duplicates enhances code readability and better adheres to OOP principles.

Let's enclose all messages shown to the user in the Ui and ParkException classes as methods. This better suits their intended purpose and makes subsequent usage of the same messages easier.